### PR TITLE
修复新版本无法更新皮肤的Bug

### DIFF
--- a/src/main/java/com/xj/skins/bungee/LoginListener.java
+++ b/src/main/java/com/xj/skins/bungee/LoginListener.java
@@ -10,6 +10,7 @@ import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.connection.LoginResult;
 import net.md_5.bungee.event.EventHandler;
 import net.md_5.bungee.event.EventPriority;
+import net.md_5.bungee.protocol.Property;
 
 
 public class LoginListener implements Listener {
@@ -32,8 +33,8 @@ public class LoginListener implements Listener {
                     if (property == null) {
                         loginProfile.setProperties(null);
                     } else {
-                        LoginResult.Property textures = new LoginResult.Property("textures", property.getValue(), property.getSignature());
-                        loginProfile.setProperties(new LoginResult.Property[]{textures});
+                        Property textures = new Property("textures", property.getValue(), property.getSignature());
+                        loginProfile.setProperties(new Property[]{textures});
                         instance.getLogger().info(String.format("Inject textures for %s", nickName));
                     }
                     Reflections.setValue(connection, "loginProfile", loginProfile);


### PR DESCRIPTION
BungeeCord最新版本里，Property不在是LoginResult内部类，导致原有的`new LoginResult.Property()`构造函数失效，无法正确修改玩家皮肤。

**以前**
> `LoginResult.Property` textures = `new LoginResult.Property`("textures", property.getValue(), property.getSignature());
                        loginProfile.setProperties(`new LoginResult.Property[]`{textures});

**现在**
> `Property` textures = `new Property`("textures", property.getValue(), property.getSignature());
                        loginProfile.setProperties(`new Property[]`{textures});
                        